### PR TITLE
[DA-3868] - Try to decompressing data streams first

### DIFF
--- a/PyPDF2/filters.py
+++ b/PyPDF2/filters.py
@@ -48,7 +48,7 @@ try:
     import zlib
 
     def decompress(data):
-        return zlib.decompress(data)
+        return zlib.decompressobj().decompress(data)
 
     def compress(data):
         return zlib.compress(data)


### PR DESCRIPTION
This change will force `zlib` decompressing data streams that won’t fit into memory first and then fall back to the usual decompress method.

It is intended to fix those events https://sentry.drchrono.com/drchrono/drchrono-web/issues/245739 with the message `Error -5 while decompressing data: incomplete or truncated stream` and it is based on https://github.com/mstamy2/PyPDF2/issues/88

You can get a broken PDF by going to Sentry event and getting the ConsentFormSignature id from the stack trace and then under prod or staging `djsp` you get the signed URL for the file.

```python
cfs = ConsentFormSignature.objects.get(pk=XXXXXX)
cf = cfs.consent_form
print cf.uri.url
````

Download the file to your computer and use this script to test it

```python
from PyPDF2 import PdfFileReader, PdfFileWriter

cf = PdfFileReader("broken-pdf.pdf")

output = PdfFileWriter()

num_pages = cf.getNumPages()

for i in range(num_pages):
    output.addPage(cf.getPage(i))

output_stream = open("fixedFile3.pdf", "wb")
output.write(output_stream)
output_stream.close()

```

It Should blow up with this error without this change `error: Error -5 while decompressing data: incomplete or truncated stream`  but then work with this change.