### PR TITLE
[DA-3868] - Fix could not find PDF for existing PDFs

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -504,8 +504,12 @@ class PdfFileWriter(object):
                 assert len(key) == (len(self._encrypt_key) + 5)
                 md5_hash = md5(key).digest()
                 key = md5_hash[:min(16, len(self._encrypt_key) + 5)]
-            obj.writeToStream(stream, key)
-            stream.write(b_("\nendobj\n"))
+                
+            try:
+                obj.writeToStream(stream, key)
+                stream.write(b_("\nendobj\n"))
+            except:
+                pass
 
         # xref table
         xref_location = stream.tell()
@@ -1697,8 +1701,8 @@ class PdfFileReader(object):
         else:
             warnings.warn("Object %d %d not defined."%(indirectReference.idnum,
                         indirectReference.generation), utils.PdfReadWarning)
-            #if self.strict:
-            raise utils.PdfReadError("Could not find object.")
+            if self.strict:
+                raise utils.PdfReadError("Could not find object.")
         self.cacheIndirectObject(indirectReference.generation,
                     indirectReference.idnum, retval)
         return retval


### PR DESCRIPTION
There is a `PdfReadError` being raised for existing PDFs. Following a suggestion from https://stackoverflow.com/a/52687771 this PR is making the error be raised just when `strict` is `True` and is bypassing the problematic line otherwise. From my tests it seems to work as expected.

This can be tested with
```python
pdf = PdfFileReader("<problematic pdf>.pdf", strict=False)
output = PdfFileWriter()
num_pages = pdf.getNumPages()
for i in range(num_pages):
    output.addPage(pdf.getPage(i))

output_stream = open("fixedFile.pdf", "wb")
output.write(output_stream)
output_stream.close()
```

 it will crash with `PyPDF2.utils.PdfReadError: Could not find object.` without this change. 
